### PR TITLE
fix(actions): grant bad-pr workflow permission to add labels

### DIFF
--- a/.github/workflows/bad-pr.yml
+++ b/.github/workflows/bad-pr.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, reopened]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   close-pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation
- The `actions-ecosystem/action-add-labels@v1` step in `.github/workflows/bad-pr.yml` failed with `HttpError: Resource not accessible by integration` because the workflow had no explicit token permissions and therefore could not call the Issues API to add labels.

### Description
- Added a workflow-level `permissions` block to `.github/workflows/bad-pr.yml` with `contents: read` and `issues: write` so the label step can call the Issues API when triggered by `pull_request_target`.

### Testing
- Verified the change by inspecting the diff with `git diff` and the updated file with `nl -ba .github/workflows/bad-pr.yml`, and committed the change with `git commit`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbc80ed950832e83e6782d961815cd)