### PR TITLE
Expand Policy Optimization post with LLM-focused PPO and DPO sections

### DIFF
--- a/content/posts/2026/2026-01-20-Policy Optimization.mdx
+++ b/content/posts/2026/2026-01-20-Policy Optimization.mdx
@@ -20,7 +20,7 @@ excerpt: >-
   Setting 통계학적인 관점에서, 강화학습(RL)은 uncertainty 하에서 이루어지는 sequential decision making
   혹은 dynamic optimization 이라고 할 수 있다. 일반적인 supervised learning 세팅에서는 관측 데이터
   $(X,Y)$ 쌍들로부터 conditional distribution $\Pr(Y|X)$ 를 학습하는 것인 반면,...
-readingTimeMinutes: 2
+readingTimeMinutes: 8
 useMath: true
 featured: false
 draft: false
@@ -123,8 +123,6 @@ $$
 \max_\theta \hat{\mathbb{E}}_{t} \left[ \frac{\pi_{\theta}(a_t|s_t)}{\pi_{\theta_{old}}(a_t|s_t)} \hat{A}_t - \beta D_{KL} \left( \pi_{\theta_{old}}(\cdot|s_t) \| \pi_{\theta}(\cdot|s_t) \right) \right]
 $$
 
-또한, 
-
 ### Clipped Surrogate Objective
 	
 PPO는 TRPO의 복잡성을 줄이기 위해 clipped surrogate objective를 도입한다. TRPO의 objective 내 비율 항목을 다음과 같이 정의한다.
@@ -147,3 +145,212 @@ $$
 - Schulman, John, Sergey Levine, Pieter Abbeel, Michael Jordan, and Philipp Moritz. 2015. “Trust Region Policy Optimization.” Proceedings of the 32nd International Conference on Machine Learning, June 1, 1889–97. https://proceedings.mlr.press/v37/schulman15.html.
 
 - Schulman, John, Filip Wolski, Prafulla Dhariwal, Alec Radford, and Oleg Klimov. 2017. “Proximal Policy Optimization Algorithms.” arXiv:1707.06347. Preprint, arXiv, August 28. https://doi.org/10.48550/arXiv.1707.06347.
+
+
+# LLM에서의 Policy Optimization
+
+위에서 정의한 policy optimization 관점은 LLM alignment에도 거의 그대로 대응된다. 차이는 **환경(environment)** 과 **행동(action)** 의 해석이다. 일반적인 게임 RL에서는 상태가 게임 화면이고 행동이 조작 입력이라면, LLM에서는 상태가 prompt와 지금까지 생성한 context이고 행동은 다음 token 선택이다.
+
+$$
+\begin{aligned}
+s_t &= (x, y_{<t}) \\
+a_t &= y_t \\
+\tau &= (x, y_1,\ldots,y_T) \\
+\pi_\theta(y|x) &= \prod_{t=1}^{T} \pi_\theta(y_t | x, y_{<t}) \\
+\log \pi_\theta(y|x) &= \sum_{t=1}^{T} \log \pi_\theta(y_t | x, y_{<t})
+\end{aligned}
+$$
+
+따라서 LLM의 policy optimization은 다음과 같이 볼 수 있다.
+
+- **Policy**: language model $\pi_\theta(y|x)$
+- **State**: prompt $x$와 partial completion $y_{<t}$
+- **Action**: next token $y_t$
+- **Reward**: 사람 선호, 안전성, 유용성 등을 반영한 scalar score $r(x,y)$
+- **Reference policy**: 보통 SFT가 끝난 모델 $\pi_{ref}$ 혹은 이전 policy $\pi_{old}$
+
+여기서 중요한 점은 reward가 token마다 dense하게 주어지는 경우보다, 완성된 답변 $y$ 전체에 대해 하나의 점수로 주어지는 경우가 많다는 것이다. 즉, LLM alignment에서는 episodic RL에 가까운 세팅으로,
+
+$$
+J(\theta) = \mathbb{E}_{x \sim \mathcal{D},\; y \sim \pi_\theta(\cdot|x)}[r(x,y)]
+$$
+
+와 같은 목적함수를 생각할 수 있다. 하지만 reward만 최대화하면 모델이 원래의 language modeling 능력에서 크게 벗어나거나 reward model을 exploit할 수 있으므로, 실제로는 reference model과의 KL divergence를 함께 제어한다.
+
+$$
+\max_\theta \; \mathbb{E}_{x,y \sim \pi_\theta}
+\left[ r(x,y) - \beta D_{KL}(\pi_\theta(\cdot|x) \| \pi_{ref}(\cdot|x)) \right]
+$$
+
+직관적으로는 **보상은 높이고 싶지만, SFT 모델에서 너무 멀어지지는 않게 하는 것**이다.
+
+## RLHF Pipeline: SFT $\rightarrow$ Reward Model $\rightarrow$ PPO
+
+InstructGPT류의 RLHF pipeline은 대략 다음 3단계로 정리할 수 있다.
+
+1. **Supervised Fine-Tuning (SFT)**
+   - 사람이 작성한 prompt-response pair로 language model을 supervised learning한다.
+   - 이 모델이 이후의 reference policy $\pi_{ref}$가 된다.
+2. **Reward Model (RM) 학습**
+   - 같은 prompt에 대해 여러 답변을 만들고, 사람이 선호 순위를 매긴다.
+   - reward model $r_\phi(x,y)$는 어떤 답변이 더 선호되는지 예측하도록 학습된다.
+3. **PPO로 policy 최적화**
+   - 현재 policy $\pi_\theta$가 답변을 생성한다.
+   - reward model이 점수 $r_\phi(x,y)$를 준다.
+   - KL penalty를 포함한 reward로 PPO 업데이트를 수행한다.
+
+Reward model은 보통 pairwise preference data로 학습한다. prompt $x$에 대해 사람이 선호한 답변을 $y_w$, 덜 선호한 답변을 $y_l$라고 하면 Bradley-Terry 형태의 loss를 사용할 수 있다.
+
+$$
+\mathcal{L}_{RM}(\phi)
+= - \mathbb{E}_{(x,y_w,y_l)}
+\left[ \log \sigma(r_\phi(x,y_w)-r_\phi(x,y_l)) \right]
+$$
+
+이후 PPO 단계에서는 reward model score에 KL penalty를 더한 shaped reward를 쓴다.
+
+$$
+\tilde{r}(x,y)
+= r_\phi(x,y) - \beta \log \frac{\pi_\theta(y|x)}{\pi_{ref}(y|x)}
+$$
+
+Token-level로 쓰면 다음과 같이 각 token의 log-ratio를 합산한 항이 KL penalty 역할을 한다.
+
+$$
+\log \frac{\pi_\theta(y|x)}{\pi_{ref}(y|x)}
+= \sum_{t=1}^{T}
+\left[ \log \pi_\theta(y_t|x,y_{<t})
+- \log \pi_{ref}(y_t|x,y_{<t}) \right]
+$$
+
+결국 LLM에서 PPO는 다음과 같은 형태의 optimization으로 이해할 수 있다.
+
+$$
+\max_\theta \; \hat{\mathbb{E}}_t
+\left[
+\min\left(
+ r_t(\theta)\hat{A}_t,
+ \text{clip}(r_t(\theta),1-\epsilon,1+\epsilon)\hat{A}_t
+\right)
+\right]
+$$
+
+단, 여기서 $r_t(\theta)$는 token action에 대한 확률비이다.
+
+$$
+r_t(\theta)=
+\frac{\pi_\theta(y_t|x,y_{<t})}
+{\pi_{old}(y_t|x,y_{<t})}
+$$
+
+LLM PPO에서 value function은 prompt와 partial completion을 보고 남은 return을 예측하는 critic으로 붙는다. 즉, actor는 next-token distribution을 내고, critic은 $V_\psi(x,y_{<t})$를 예측한다. Advantage는 reward model score와 KL penalty를 반영한 return으로부터 GAE(Generalized Advantage Estimation) 등을 통해 추정한다.
+
+### 왜 LLM에서 PPO가 어려운가?
+
+PPO는 이론적으로는 자연스럽지만 LLM에 적용할 때 꽤 무겁다.
+
+- **Sampling cost**: policy가 직접 답변을 생성해야 하므로 rollout 비용이 크다.
+- **Reward model dependency**: reward model이 잘못 학습되면 reward hacking이 발생할 수 있다.
+- **Actor-critic complexity**: policy model, reference model, reward model, value model을 함께 다뤄야 한다.
+- **Hyperparameter sensitivity**: KL coefficient $\beta$, clipping range $\epsilon$, learning rate, advantage normalization 등에 민감하다.
+- **On-policy 성격**: 새 policy에서 생성한 sample로 업데이트해야 하므로 supervised fine-tuning보다 data efficiency가 낮다.
+
+이러한 이유로, PPO는 RLHF의 대표적인 방법이지만 구현과 운영 비용이 큰 편이다. 이 지점에서 등장하는 더 단순한 대안 중 하나가 DPO이다.
+
+# DPO(Direct Preference Optimization)
+
+DPO의 핵심 아이디어는 **reward model을 명시적으로 학습한 뒤 PPO로 최적화하지 말고, preference data로부터 policy를 직접 학습하자**는 것이다. 즉, RLHF pipeline의 RM 학습과 RL optimization 단계를 하나의 supervised-looking loss로 합친다.
+
+출발점은 KL-regularized reward maximization이다.
+
+$$
+\max_{\pi} \; \mathbb{E}_{x \sim \mathcal{D}, y \sim \pi(\cdot|x)}
+\left[ r(x,y) \right]
+- \beta D_{KL}(\pi(y|x) \| \pi_{ref}(y|x))
+$$
+
+이 문제의 최적 policy는 다음과 같은 Boltzmann distribution 형태를 가진다.
+
+$$
+\pi^*(y|x)
+= \frac{1}{Z(x)}\pi_{ref}(y|x)\exp\left(\frac{1}{\beta}r(x,y)\right)
+$$
+
+이를 reward에 대해 정리하면,
+
+$$
+r(x,y)
+= \beta \log \frac{\pi^*(y|x)}{\pi_{ref}(y|x)} + \beta \log Z(x)
+$$
+
+가 된다. 같은 prompt $x$에서 두 답변 $y_w,y_l$를 비교하면 partition function $Z(x)$는 서로 상쇄된다.
+
+$$
+r(x,y_w)-r(x,y_l)
+= \beta
+\left[
+\log \frac{\pi^*(y_w|x)}{\pi_{ref}(y_w|x)}
+-
+\log \frac{\pi^*(y_l|x)}{\pi_{ref}(y_l|x)}
+\right]
+$$
+
+DPO는 여기서 최적 policy $\pi^*$를 현재 학습 중인 policy $\pi_\theta$로 parameterize하고, Bradley-Terry preference likelihood에 대입한다. 따라서 DPO loss는 다음과 같다.
+
+$$
+\mathcal{L}_{DPO}(\theta)
+= - \mathbb{E}_{(x,y_w,y_l) \sim \mathcal{D}}
+\left[
+\log \sigma
+\left(
+\beta
+\left(
+\log \frac{\pi_\theta(y_w|x)}{\pi_{ref}(y_w|x)}
+-
+\log \frac{\pi_\theta(y_l|x)}{\pi_{ref}(y_l|x)}
+\right)
+\right)
+\right]
+$$
+
+Sequence log-probability는 token log-probability의 합이다.
+
+$$
+\log \pi_\theta(y|x)
+= \sum_{t=1}^{T} \log \pi_\theta(y_t|x,y_{<t})
+$$
+
+이 loss의 의미는 단순하다.
+
+- 선호 답변 $y_w$에 대해서는 $\pi_\theta(y_w|x)$를 $\pi_{ref}(y_w|x)$ 대비 더 크게 만든다.
+- 비선호 답변 $y_l$에 대해서는 $\pi_\theta(y_l|x)$를 $\pi_{ref}(y_l|x)$ 대비 더 작게 만든다.
+- 단, $\beta$가 reference policy에서 얼마나 멀어질지 조절한다.
+
+## DPO vs PPO
+
+| 구분 | PPO-based RLHF | DPO |
+|---|---|---|
+| 학습 데이터 | prompt, generated response, reward model score | preference pair $(x,y_w,y_l)$ |
+| Reward model | 필요 | 명시적으로는 불필요 |
+| Value model | 필요 | 불필요 |
+| Sampling | on-policy rollout 필요 | offline preference data로 가능 |
+| 목적함수 | clipped policy gradient + KL penalty | pairwise logistic loss |
+| 구현 난이도 | 높음 | 상대적으로 낮음 |
+| 주요 리스크 | reward hacking, unstable RL | preference data 품질과 reference 선택에 민감 |
+
+요약하면 PPO는 **reward model이 정의한 보상을 직접 최대화하는 RL 방법**이고, DPO는 **선호 비교 데이터를 이용해 KL-regularized optimal policy를 직접 fitting하는 방법**이다. PPO가 더 일반적인 RL framework에 가깝다면, DPO는 LLM preference tuning에 특화된 더 단순한 objective라고 볼 수 있다.
+
+## 한 줄 직관
+
+- **PPO**: "이 답변의 reward가 높으니, 그 답변을 만들 확률을 조금 높이자. 단, 너무 급격히 바꾸지는 말자."
+- **DPO**: "같은 prompt에서 사람이 고른 답변은 reference 대비 더 가능하게, 버린 답변은 reference 대비 덜 가능하게 만들자."
+
+# 마무리
+
+Policy optimization은 강화학습의 일반적인 수학적 틀이지만, LLM에서는 next-token prediction model을 policy로 해석하면서 alignment 방법론과 직접 연결된다. PPO는 RLHF의 고전적인 접근으로 reward model과 KL-regularized policy update를 사용하고, DPO는 preference likelihood를 통해 그 과정을 더 직접적인 supervised objective로 바꾼다. 결국 두 방법 모두 핵심은 동일하다. **사람이 선호하는 응답의 확률은 높이고, 원래 모델의 언어 능력과 분포에서는 너무 멀어지지 않도록 제어하는 것**이다.
+
+- Ouyang, Long, Jeffrey Wu, Xu Jiang, Diogo Almeida, Carroll Wainwright, Pamela Mishkin, Chong Zhang, et al. 2022. “Training Language Models to Follow Instructions with Human Feedback.” arXiv:2203.02155. Preprint, arXiv, March 4. https://doi.org/10.48550/arXiv.2203.02155.
+
+- Rafailov, Rafael, Archit Sharma, Eric Mitchell, Christopher D. Manning, Stefano Ermon, and Chelsea Finn. 2023. “Direct Preference Optimization: Your Language Model Is Secretly a Reward Model.” Advances in Neural Information Processing Systems 36. https://arxiv.org/abs/2305.18290.
+
+- Christiano, Paul F., Jan Leike, Tom B. Brown, Miljan Martic, Shane Legg, and Dario Amodei. 2017. “Deep Reinforcement Learning from Human Preferences.” Advances in Neural Information Processing Systems 30. https://arxiv.org/abs/1706.03741.


### PR DESCRIPTION
### Motivation
- Extend the existing Policy Optimization post to connect classical RL policy optimization to LLM alignment and RLHF workflows.
- Clarify how policy/state/action/reward map to language models and provide derivations/intuition for PPO in LLMs.
- Present DPO as an alternative to PPO for preference-based tuning and compare the objectives and practical trade-offs.

### Description
- Updated metadata `readingTimeMinutes` from `2` to `8` to reflect the expanded article length.
- Removed a stray fragment and streamlined the PPO section, then added a new `LLM에서의 Policy Optimization` section showing token-level policy math and the KL-regularized objective.
- Added an `RLHF Pipeline` subsection describing SFT → Reward Model → PPO, the reward-model loss, KL penalty and token-level ratios, and a full `DPO(Direct Preference Optimization)` section with derivation, loss, and a PPO vs DPO comparison table.
- Appended intuitive one-line summaries, a closing section, and related references.

### Testing
- Ran `npm run validate:content` which completed successfully and reported validation of migrated content files.
- Ran `npm run content:prepare` (which runs `generate:content` + `validate:content`) and it completed successfully, producing content artifacts.
- Ran `npm run build` which executed but failed in this environment because Google font assets could not be fetched from `fonts.gstatic.com`, causing the Next.js build font-fetch step to fail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03b4a1c6d8832e8d2e40dc065b9a17)